### PR TITLE
Diff improvements

### DIFF
--- a/polygon_cli/actions/add.py
+++ b/polygon_cli/actions/add.py
@@ -6,8 +6,6 @@ from ..local_file import LocalFile
 
 
 def process_add(file_type, solution_type, files):
-    if not load_session():
-        fatal('No session known. Use relogin or init first.')
     real_file_type = file_type
     if file_type in ['checker', 'validator', 'interactor']:
         if len(files) != 1:
@@ -41,7 +39,6 @@ def process_add(file_type, solution_type, files):
                 status = colors.error('Error')
         table.add_row([local.type, local.polygon_filename, local.filename, status])
     print(table)
-    save_session()
 
 
 def add_parser(subparsers):
@@ -56,4 +53,11 @@ def add_parser(subparsers):
                             choices=['MAIN', 'OK', 'RJ', 'TL', 'WA', 'PE', 'ML', 'RE', 'TO'],
                             help='Solution type')
     parser_add.add_argument('file', nargs='+', help='List of files to add')
-    parser_add.set_defaults(func=lambda options: process_add(options.file_type, options.solution_type, options.file))
+
+    def read_options(options):
+        if not load_session_with_options(options):
+            fatal('No session known. Use relogin or init first.')
+        process_add(options.file_type, options.solution_type, options.file)
+        save_session()
+
+    parser_add.set_defaults(func=read_options)

--- a/polygon_cli/actions/commit.py
+++ b/polygon_cli/actions/commit.py
@@ -5,8 +5,6 @@ from .. import colors
 
 
 def process_commit(to_commit):
-    if not load_session():
-        fatal('No session known. Use relogin or init first.')
     files = global_vars.problem.local_files
     polygon_files = global_vars.problem.get_all_files_list()
     table = PrettyTable(['File type', 'Polygon name', 'Local path', 'Status'])
@@ -61,7 +59,6 @@ def process_commit(to_commit):
                 break
             table.add_row([file.type, file.polygon_filename, file.get_path(), status])
     print(table)
-    save_session()
 
 
 def add_parser(subparsers):
@@ -70,4 +67,10 @@ def add_parser(subparsers):
             help="Put all local changes to polygon. Not making a commit in polygon"
     )
     parser_commit.add_argument('file', nargs='*', help='List of files to commit')
-    parser_commit.set_defaults(func=lambda options: process_commit(options.file))
+
+    def read_options(options):
+        if not load_session_with_options(options):
+            fatal('No session known. Use relogin or init first.')
+        process_commit(options.file)
+        save_session()
+    parser_commit.set_defaults(func=read_options)

--- a/polygon_cli/actions/common.py
+++ b/polygon_cli/actions/common.py
@@ -13,7 +13,7 @@ def fatal(error):
     exit(0)
 
 
-def load_session():
+def load_session(verbose=True):
     try:
         if os.path.exists(config.get_session_file_path()):
             session_data_json = open(config.get_session_file_path(), 'r').read()
@@ -23,7 +23,7 @@ def load_session():
         else:
             return False
         session_data = json.loads(session_data_json, object_hook=json_encoders.my_json_decoder)
-        global_vars.problem = ProblemSession(config.polygon_url, session_data["problemId"])
+        global_vars.problem = ProblemSession(config.polygon_url, session_data["problemId"], verbose=verbose)
         global_vars.problem.use_ready_session(session_data)
         return True
     except:

--- a/polygon_cli/actions/common.py
+++ b/polygon_cli/actions/common.py
@@ -30,6 +30,14 @@ def load_session(verbose=True):
         return False
 
 
+def get_session_options(options):
+    return {'verbose': options.verbose}
+
+
+def load_session_with_options(options):
+    return load_session(options.verbose)
+
+
 def save_session():
     session_data = global_vars.problem.dump_session()
     session_data_json = json.dumps(session_data, sort_keys=True, indent='  ', default=json_encoders.my_json_encoder)

--- a/polygon_cli/actions/diff.py
+++ b/polygon_cli/actions/diff.py
@@ -3,9 +3,10 @@ import os.path
 
 
 def process_diff(options):
+    # resolve paths before load_session changes working directory
     input_files = list(map(os.path.abspath, options.file))
 
-    if not load_session():
+    if not load_session(verbose=options.verbose):
         fatal('No session known. Use init first.')
 
     polygon_files = global_vars.problem.get_all_files_list()

--- a/polygon_cli/actions/gettest.py
+++ b/polygon_cli/actions/gettest.py
@@ -1,16 +1,16 @@
 from .common import *
 
 
-def process_get_test(tests):
-    if not load_session():
+def process_get_test(options):
+    if not load_session_with_options(options):
         fatal('No session known. Use init first.')
-    for i in tests:
+    for i in options.numbers:
         global_vars.problem.download_test(i)
     save_session()
 
 
-def process_get_all_tests():
-    if not load_session():
+def process_get_all_tests(options):
+    if not load_session_with_options(options):
         fatal('No session known. Use init first.')
     global_vars.problem.download_all_tests()
     save_session()
@@ -22,10 +22,10 @@ def add_parser(subparsers):
             help="Downloads test with given numbers"
     )
     parser_get_test.add_argument('numbers', nargs='+', help='Tests to download')
-    parser_get_test.set_defaults(func=lambda options: process_get_test(options.numbers))
+    parser_get_test.set_defaults(func=process_get_test)
 
     parser_get_all_tests = subparsers.add_parser(
             'getalltests',
             help="Downloads alls tests"
     )
-    parser_get_all_tests.set_defaults(func=lambda options: process_get_all_tests())
+    parser_get_all_tests.set_defaults(func=process_get_all_tests)

--- a/polygon_cli/actions/import_package.py
+++ b/polygon_cli/actions/import_package.py
@@ -1,10 +1,10 @@
 from .common import *
 
 
-def process_import_problem_from_package(directory):
-    if not load_session():
+def process_import_problem_from_package(options):
+    if not load_session_with_options(options):
         fatal('No session known. Use relogin or init first.')
-    global_vars.problem.import_problem_from_package(directory)
+    global_vars.problem.import_problem_from_package(options.directory)
     save_session()
 
 
@@ -16,4 +16,4 @@ def add_parser(subparsers):
     parser_import_problem_from_package.\
         add_argument('directory', help='Extracted package directory, which contains problem.xml')
     parser_import_problem_from_package.\
-        set_defaults(func=lambda options: process_import_problem_from_package(options.directory))
+        set_defaults(func=process_import_problem_from_package)

--- a/polygon_cli/actions/init.py
+++ b/polygon_cli/actions/init.py
@@ -6,9 +6,9 @@ from .. import config
 from .. import global_vars
 
 
-def process_init(problem_id):
+def process_init(problem_id, **session_options):
     if not problem_id.isdigit():
-        session = ProblemSession(config.polygon_url, None)
+        session = ProblemSession(config.polygon_url, None, **session_options)
         problems = session.send_api_request('problems.list', {}, problem_data=False)
         list = []
         for i in problems:
@@ -31,8 +31,8 @@ def process_init(problem_id):
     save_session()
 
 
-def process_init_contest(contest_id):
-    contest = ProblemSession(config.polygon_url, None)
+def process_init_contest(contest_id, **session_options):
+    contest = ProblemSession(config.polygon_url, None, **session_options)
     problems = contest.get_contest_problems(contest_id)
     print(problems)
     result = PrettyTable(['Problem name', 'Problem id', 'Status'])
@@ -61,11 +61,11 @@ def add_parser(subparsers):
             help="Initialize tool"
     )
     parser_init.add_argument('problem_id', help='Problem id to work with')
-    parser_init.set_defaults(func=lambda options: process_init(options.problem_id))
+    parser_init.set_defaults(func=lambda options: process_init(options.problem_id, **get_session_options(options)))
 
     parser_init_contest = subparsers.add_parser(
             'init_contest',
             help="Initialize tool for several problems in one contest"
     )
     parser_init_contest.add_argument('contest_id', help='Contest id to init')
-    parser_init_contest.set_defaults(func=lambda options: process_init_contest(options.contest_id))
+    parser_init_contest.set_defaults(func=lambda options: process_init_contest(options.contest_id, **get_session_options(options)))

--- a/polygon_cli/actions/list.py
+++ b/polygon_cli/actions/list.py
@@ -4,8 +4,6 @@ from .common import *
 
 
 def process_list():
-    if not load_session():
-        fatal('No session known. Use init first.')
     files = global_vars.problem.get_all_files_list()
     local_files = global_vars.problem.local_files
     table = PrettyTable(['File type', 'Polygon name', 'Local path', 'Local name'])
@@ -22,7 +20,6 @@ def process_list():
             continue
         table.add_row([file.type, '!' + file.polygon_filename, file.get_path(), file.name])
     print(table)
-    save_session()
 
 
 def add_parser(subparsers):
@@ -30,4 +27,10 @@ def add_parser(subparsers):
             'list',
             help="List files in polygon"
     )
-    parser_list.set_defaults(func=lambda options: process_list())
+
+    def read_options(options):
+        if not load_session_with_options(options):
+            fatal('No session known. Use init first.')
+        process_list()
+        save_session()
+    parser_list.set_defaults(func=read_options)

--- a/polygon_cli/actions/package.py
+++ b/polygon_cli/actions/package.py
@@ -1,8 +1,8 @@
 from .common import *
 
 
-def process_download_last_package():
-    if not load_session():
+def process_download_last_package(options):
+    if not load_session_with_options(options):
         fatal('No session known. Use relogin or init first.')
     global_vars.problem.download_last_package()
     save_session()
@@ -13,4 +13,4 @@ def add_parser(subparsers):
             'download_package',
             help="Downloads package"
     )
-    parser_download_package.set_defaults(func=lambda options: process_download_last_package())
+    parser_download_package.set_defaults(func=process_download_last_package)

--- a/polygon_cli/actions/update.py
+++ b/polygon_cli/actions/update.py
@@ -6,8 +6,6 @@ from ..local_file import LocalFile
 
 
 def process_update(flat, to_update):
-    if not load_session():
-        fatal('No session known. Use init first.')
     files = global_vars.problem.get_all_files_list()
     table = PrettyTable(['File type', 'Polygon name', 'Local path', 'Status'])
     for file in files:
@@ -46,7 +44,6 @@ def process_update(flat, to_update):
             global_vars.problem.local_files.append(local_file)
         table.add_row([file.type, file.name, local_file.get_path(), status])
     print(table)
-    save_session()
 
 
 def add_parser(subparsers):
@@ -56,4 +53,10 @@ def add_parser(subparsers):
     )
     parser_update.add_argument('--flat', action='store_true', help='Load files in current folder, not subdirectories')
     parser_update.add_argument('file', nargs='*', help='List of files to download (all by default)')
-    parser_update.set_defaults(func=lambda options: process_update(options.flat, options.file))
+
+    def process_options(options):
+        if not load_session_with_options(options):
+            fatal('No session known. Use init first.')
+        process_update(options.flat, options.file)
+        save_session()
+    parser_update.set_defaults(func=process_options)

--- a/polygon_cli/actions/update_groups.py
+++ b/polygon_cli/actions/update_groups.py
@@ -1,8 +1,8 @@
 from .common import *
 
 
-def update_groups():
-    if not load_session():
+def update_groups(options):
+    if not load_session_with_options(options):
         fatal('No session known. Use init first.')
     content = global_vars.problem.get_script_content()
     global_vars.problem.update_groups(content)
@@ -14,4 +14,4 @@ def add_parser(subparsers):
             'update_groups',
             help="Update groups for tests using script file"
     )
-    parser_update_groups.set_defaults(func=lambda options: update_groups())
+    parser_update_groups.set_defaults(func=update_groups)

--- a/polygon_cli/polygon_cli.py
+++ b/polygon_cli/polygon_cli.py
@@ -15,6 +15,15 @@ from .actions import update_groups as update_groups_action
 from .exceptions import PolygonNotLoginnedError
 
 parser = argparse.ArgumentParser(prog="polygon-cli")
+parser.add_argument('-v', '--verbose',
+                    action='store_true',
+                    dest='verbose',
+                    default=True,
+                    help='Verbose output')
+parser.add_argument('-nv', '--no-verbose',
+                    action='store_false',
+                    dest='verbose',
+                    help='Reduce output verbosity')
 subparsers = parser.add_subparsers(
         title='available subcommands',
         description='',

--- a/polygon_cli/polygon_cli.py
+++ b/polygon_cli/polygon_cli.py
@@ -20,7 +20,7 @@ parser.add_argument('-v', '--verbose',
                     dest='verbose',
                     default=True,
                     help='Verbose output')
-parser.add_argument('-nv', '--no-verbose',
+parser.add_argument('-V', '--no-verbose',
                     action='store_false',
                     dest='verbose',
                     help='Reduce output verbosity')

--- a/polygon_cli/problem.py
+++ b/polygon_cli/problem.py
@@ -41,7 +41,7 @@ def parse_api_file_list(files, files_raw, type):
 
 
 class ProblemSession:
-    def __init__(self, address, problem_id):
+    def __init__(self, address, problem_id, verbose=True):
         """
 
         :type address: str
@@ -56,6 +56,7 @@ class ProblemSession:
         self.ccid = None
         self.local_files = []
         self.relogin_done = False
+        self.verbose = verbose
 
     def use_ready_session(self, data):
         """
@@ -146,8 +147,9 @@ class ProblemSession:
         return result
 
     def send_api_request(self, api_method, params, is_json=True, problem_data=True):
-        print('Invoking ' + api_method, end=' ')
-        sys.stdout.flush()
+        if self.verbose:
+            print('Invoking ' + api_method, end=' ')
+            sys.stdout.flush()
         params["apiKey"] = config.api_key
         params["time"] = int(time.time())
         if problem_data:
@@ -164,7 +166,10 @@ class ProblemSession:
         params["apiSig"] = signature_random + utils.convert_to_bytes(hashlib.sha512(signature_string).hexdigest())
         url = self.polygon_address + '/api/' + api_method
         result = self.session.request('POST', url, files=params)
-        print(result.status_code)
+        if self.verbose or result.status_code != 200:
+            if not self.verbose:
+                print('Invoking ' + api_method, end=' ')
+            print(result.status_code)
         if not is_json and result.status_code == 200:
             return result.content
         result = json.loads(result.content.decode('utf8'))

--- a/polygon_cli/problem.py
+++ b/polygon_cli/problem.py
@@ -352,6 +352,18 @@ class ProblemSession:
                 return local
         return None
 
+    def get_local_by_path(self, path):
+        """
+
+        :type path: str
+        :rtype: local_file.LocalFile or None
+        """
+        path = os.path.normpath(os.path.relpath(path, "."))
+        for local in self.local_files:
+            if os.path.normpath(local.get_path()) == path:
+                return local
+        return None
+
     def download_test(self, test_num, test_directory='.'):
         """
 

--- a/polygon_cli/utils.py
+++ b/polygon_cli/utils.py
@@ -3,9 +3,9 @@
 import os
 import re
 import shutil
-import string
 import sys
 from subprocess import Popen, PIPE
+import subprocess
 
 from . import config
 
@@ -18,7 +18,9 @@ def read_file(filename):
 
 
 def diff_files(old, our, theirs):
-    Popen(config.get_diff_tool(old, our, theirs), stdout=sys.stdout, shell=True)
+    subprocess.run(config.get_diff_tool(old, our, theirs),
+                   stdout=sys.stdout,
+                   shell=True)
 
 
 def safe_rewrite_file(path, content, openmode='wb'):


### PR DESCRIPTION
Allow specifying local file paths and multiple files for diff command. It is very useful in combination with  autocomplete and wildcard functionality provided by  most shells. 

Also added verbosity flags which can be used to obtain clean diff without information about successful network requests. It is currently implemented for diff, but could be easily added to other commands.